### PR TITLE
feat(quick-notes): Add handwriting support and multi-note display

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,31 @@ A comprehensive productivity timer system with advanced features for focused wor
   - **Clock Page** - Full sidebar page with tabs (Timer, Multi-Timer, Routines, Stats, Settings)
   - **Synchronized State** - Changes in either view reflect in the other
 
+### **Quick Notes (NEW)**
+Ephemeral note-taking for those quick thoughts that don't need permanent storage.
+
+- **Instant Access**
+  - **Floating Hub Integration** - One-tap access from the floating menu
+  - **Browse Page Widget** - Collapsible card above your files
+  - **Real-Time Sync** - Changes reflect immediately across all views
+
+- **Auto-Expiration**
+  - **Configurable Retention** - Notes auto-delete after a set time
+  - **Preset Durations** - 15min, 30min, 1hr, 4hr, 12hr, 24hr, 3 days, 1 week
+  - **Expiry Countdown** - Visual indicator showing time remaining
+  - **Manual Override** - Disable auto-delete if needed
+
+- **Input Modes**
+  - **Text Mode** - Quick text entry with instant save
+  - **Handwriting Mode** - Sketch quick diagrams or handwritten notes
+  - **Mode Toggle** - Easy switch between input types
+
+- **Management**
+  - **Clear All** - Quickly remove all quick notes
+  - **Delete Individual** - Remove specific notes
+  - **Note Count Badge** - See how many quick notes you have
+  - **Settings Integration** - Configure retention from Settings page
+
 ### **Customization**
 - **Dynamic Theming** - Material You dynamic color support
 - **Dark & Light Modes** - Easy on the eyes, any time of day

--- a/VERSION
+++ b/VERSION
@@ -3,7 +3,7 @@
 # Run `dart run scripts/bump_version.dart` to update all version references.
 
 MAJOR=0
-MINOR=0
-PATCH=1
+MINOR=1
+PATCH=0
 BUILD_NUMBER=1
 

--- a/lib/components/quick_notes/floating_quick_notes.dart
+++ b/lib/components/quick_notes/floating_quick_notes.dart
@@ -1,0 +1,527 @@
+import 'package:flutter/material.dart';
+import 'package:kivixa/services/quick_notes/quick_notes_service.dart';
+
+/// A floating quick notes window that can be shown as an overlay.
+class FloatingQuickNotes extends StatefulWidget {
+  const FloatingQuickNotes({super.key, this.onClose, this.initialRect});
+
+  final VoidCallback? onClose;
+  final Rect? initialRect;
+
+  @override
+  State<FloatingQuickNotes> createState() => _FloatingQuickNotesState();
+}
+
+class _FloatingQuickNotesState extends State<FloatingQuickNotes>
+    with SingleTickerProviderStateMixin {
+  final _service = QuickNotesService.instance;
+  final _textController = TextEditingController();
+  final _focusNode = FocusNode();
+  late final TabController _tabController;
+
+  var _isHandwritingMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+    _service.addListener(_onServiceChanged);
+    _service.initialize();
+  }
+
+  void _onServiceChanged() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _service.removeListener(_onServiceChanged);
+    _textController.dispose();
+    _focusNode.dispose();
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _addNote() {
+    final content = _textController.text.trim();
+    if (content.isEmpty) return;
+
+    _service.addNote(content: content, isHandwritten: _isHandwritingMode);
+    _textController.clear();
+  }
+
+  void _clearAll() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Clear All Quick Notes?'),
+        content: const Text(
+          'This will permanently delete all quick notes. This action cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              _service.clearAllNotes();
+              Navigator.pop(context);
+            },
+            child: const Text('Clear All'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Material(
+      color: colorScheme.surface,
+      borderRadius: BorderRadius.circular(16),
+      elevation: 8,
+      child: Container(
+        constraints: const BoxConstraints(
+          minWidth: 320,
+          maxWidth: 400,
+          minHeight: 300,
+          maxHeight: 500,
+        ),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: colorScheme.outlineVariant.withValues(alpha: 0.5),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Header
+            _buildHeader(context),
+
+            // Tabs
+            TabBar(
+              controller: _tabController,
+              tabs: const [
+                Tab(text: 'Notes', icon: Icon(Icons.notes)),
+                Tab(text: 'New', icon: Icon(Icons.add)),
+              ],
+            ),
+
+            // Content
+            Expanded(
+              child: TabBarView(
+                controller: _tabController,
+                children: [
+                  _buildNotesList(context),
+                  _buildNewNoteForm(context),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: colorScheme.primaryContainer.withValues(alpha: 0.3),
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.sticky_note_2, color: colorScheme.primary, size: 24),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Quick Notes',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                if (_service.autoDeleteEnabled)
+                  Text(
+                    'Auto-delete: ${QuickNoteAutoDeletePresets.formatDuration(_service.autoDeleteDuration)}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (_service.notes.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.delete_sweep),
+              tooltip: 'Clear all notes',
+              onPressed: _clearAll,
+            ),
+          if (widget.onClose != null)
+            IconButton(
+              icon: const Icon(Icons.close),
+              tooltip: 'Close',
+              onPressed: widget.onClose,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNotesList(BuildContext context) {
+    final notes = _service.activeNotes;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    if (notes.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.note_add,
+              size: 64,
+              color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'No quick notes yet',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Add a note to get started',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.all(8),
+      itemCount: notes.length,
+      itemBuilder: (context, index) {
+        final note = notes[index];
+        return _QuickNoteCard(
+          note: note,
+          autoDeleteDuration: _service.autoDeleteDuration,
+          autoDeleteEnabled: _service.autoDeleteEnabled,
+          onDelete: () => _service.deleteNote(note.id),
+        );
+      },
+    );
+  }
+
+  Widget _buildNewNoteForm(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Mode toggle
+          SegmentedButton<bool>(
+            segments: const [
+              ButtonSegment(
+                value: false,
+                icon: Icon(Icons.text_fields),
+                label: Text('Text'),
+              ),
+              ButtonSegment(
+                value: true,
+                icon: Icon(Icons.draw),
+                label: Text('Handwriting'),
+              ),
+            ],
+            selected: {_isHandwritingMode},
+            onSelectionChanged: (value) {
+              setState(() => _isHandwritingMode = value.first);
+            },
+          ),
+
+          const SizedBox(height: 16),
+
+          // Input area
+          Expanded(
+            child: _isHandwritingMode
+                ? _buildHandwritingArea(context)
+                : _buildTextArea(context),
+          ),
+
+          const SizedBox(height: 16),
+
+          // Add button
+          FilledButton.icon(
+            onPressed: _textController.text.isNotEmpty ? _addNote : null,
+            icon: const Icon(Icons.add),
+            label: const Text('Add Quick Note'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTextArea(BuildContext context) {
+    final colorScheme = ColorScheme.of(context);
+
+    return TextField(
+      controller: _textController,
+      focusNode: _focusNode,
+      maxLines: null,
+      expands: true,
+      textAlignVertical: TextAlignVertical.top,
+      decoration: InputDecoration(
+        hintText: 'Type your quick note here...',
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+        filled: true,
+        fillColor: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+      ),
+      onChanged: (_) => setState(() {}),
+      onSubmitted: (_) => _addNote(),
+    );
+  }
+
+  Widget _buildHandwritingArea(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // Placeholder for handwriting - would integrate with the actual handwriting canvas
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outline),
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+      ),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.draw,
+              size: 48,
+              color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Handwriting mode',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Coming soon - use text mode for now',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A card displaying a single quick note.
+class _QuickNoteCard extends StatelessWidget {
+  const _QuickNoteCard({
+    required this.note,
+    required this.autoDeleteDuration,
+    required this.autoDeleteEnabled,
+    required this.onDelete,
+  });
+
+  final QuickNote note;
+  final Duration autoDeleteDuration;
+  final bool autoDeleteEnabled;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final remaining = note.remainingTime(autoDeleteDuration);
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  note.isHandwritten ? Icons.draw : Icons.text_snippet,
+                  size: 16,
+                  color: colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  _formatTime(note.createdAt),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const Spacer(),
+                if (autoDeleteEnabled)
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 2,
+                    ),
+                    decoration: BoxDecoration(
+                      color: _getExpirationColor(remaining, colorScheme),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      _formatRemaining(remaining),
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline, size: 18),
+                  onPressed: onDelete,
+                  tooltip: 'Delete note',
+                  visualDensity: VisualDensity.compact,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              note.content,
+              style: theme.textTheme.bodyMedium,
+              maxLines: 5,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _getExpirationColor(Duration remaining, ColorScheme colorScheme) {
+    if (remaining.inMinutes < 15) return Colors.red;
+    if (remaining.inHours < 1) return Colors.orange;
+    return colorScheme.primary;
+  }
+
+  String _formatTime(DateTime time) {
+    final now = DateTime.now();
+    final diff = now.difference(time);
+
+    if (diff.inMinutes < 1) return 'Just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+
+  String _formatRemaining(Duration remaining) {
+    if (remaining.inMinutes < 1) return 'Expiring';
+    if (remaining.inMinutes < 60) return '${remaining.inMinutes}m left';
+    if (remaining.inHours < 24) return '${remaining.inHours}h left';
+    return '${remaining.inDays}d left';
+  }
+}
+
+/// A compact button to open quick notes from the sidebar.
+class QuickNotesButton extends StatelessWidget {
+  const QuickNotesButton({super.key, this.onTap, this.compact = false});
+
+  final VoidCallback? onTap;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final service = QuickNotesService.instance;
+
+    return ListenableBuilder(
+      listenable: service,
+      builder: (context, _) {
+        final noteCount = service.activeNotes.length;
+
+        if (compact) {
+          return IconButton(
+            icon: Badge(
+              isLabelVisible: noteCount > 0,
+              label: Text('$noteCount'),
+              child: const Icon(Icons.sticky_note_2),
+            ),
+            tooltip: 'Quick Notes',
+            onPressed: onTap,
+          );
+        }
+
+        return Material(
+          color: colorScheme.primaryContainer.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(12),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  Badge(
+                    isLabelVisible: noteCount > 0,
+                    label: Text('$noteCount'),
+                    child: Icon(
+                      Icons.sticky_note_2,
+                      color: colorScheme.primary,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Quick Notes',
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        Text(
+                          noteCount == 0
+                              ? 'Tap to add a quick note'
+                              : '$noteCount note${noteCount > 1 ? 's' : ''} • auto-delete',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Icon(
+                    Icons.arrow_forward_ios,
+                    size: 16,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/components/quick_notes/inline_quick_notes.dart
+++ b/lib/components/quick_notes/inline_quick_notes.dart
@@ -1,0 +1,297 @@
+import 'package:flutter/material.dart';
+import 'package:kivixa/services/quick_notes/quick_notes_service.dart';
+
+/// A compact inline quick notes widget for the sidebar/browse page.
+/// Shows current quick note and allows editing.
+class InlineQuickNotes extends StatefulWidget {
+  const InlineQuickNotes({super.key});
+
+  @override
+  State<InlineQuickNotes> createState() => _InlineQuickNotesState();
+}
+
+class _InlineQuickNotesState extends State<InlineQuickNotes> {
+  final _controller = TextEditingController();
+  final _focusNode = FocusNode();
+  var _isExpanded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCurrentNote();
+    QuickNotesService.instance.addListener(_onNotesChanged);
+  }
+
+  @override
+  void dispose() {
+    QuickNotesService.instance.removeListener(_onNotesChanged);
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _onNotesChanged() {
+    if (mounted) {
+      _loadCurrentNote();
+    }
+  }
+
+  void _loadCurrentNote() {
+    final notes = QuickNotesService.instance.activeNotes;
+    if (notes.isNotEmpty) {
+      final note = notes.first;
+      if (!note.isHandwritten && _controller.text != note.content) {
+        _controller.text = note.content;
+      }
+    } else if (_controller.text.isNotEmpty) {
+      _controller.clear();
+    }
+    if (mounted) setState(() {});
+  }
+
+  void _saveNote() {
+    final text = _controller.text.trim();
+    final notes = QuickNotesService.instance.activeNotes;
+
+    if (text.isNotEmpty) {
+      if (notes.isNotEmpty) {
+        // Update existing note
+        QuickNotesService.instance.updateNote(notes.first.id, content: text);
+      } else {
+        // Create new note
+        QuickNotesService.instance.addNote(content: text);
+      }
+    }
+  }
+
+  void _clearNote() {
+    QuickNotesService.instance.clearAllNotes();
+    _controller.clear();
+    setState(() {});
+  }
+
+  String _getTimeRemaining() {
+    final notes = QuickNotesService.instance.activeNotes;
+    if (notes.isEmpty) return '';
+
+    final note = notes.first;
+    final remaining = note.remainingTime(
+      QuickNotesService.instance.autoDeleteDuration,
+    );
+
+    if (remaining == Duration.zero) return 'Expired';
+
+    if (remaining.inDays > 0) {
+      return '${remaining.inDays}d left';
+    } else if (remaining.inHours > 0) {
+      return '${remaining.inHours}h left';
+    } else if (remaining.inMinutes > 0) {
+      return '${remaining.inMinutes}m left';
+    }
+    return 'Less than 1m';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = ColorScheme.of(context);
+    final notes = QuickNotesService.instance.activeNotes;
+    final hasNote = notes.isNotEmpty;
+    final note = hasNote ? notes.first : null;
+    final isHandwriting = note?.isHandwritten ?? false;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: colorScheme.outline.withValues(alpha: 0.3)),
+      ),
+      child: AnimatedSize(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInOut,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Header
+            InkWell(
+              onTap: () => setState(() => _isExpanded = !_isExpanded),
+              borderRadius: BorderRadius.vertical(
+                top: const Radius.circular(12),
+                bottom: _isExpanded ? Radius.zero : const Radius.circular(12),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.sticky_note_2_outlined,
+                      size: 20,
+                      color: colorScheme.primary,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'Quick Note',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          color: colorScheme.onSurface,
+                        ),
+                      ),
+                    ),
+                    if (hasNote) ...[
+                      Text(
+                        _getTimeRemaining(),
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                    ],
+                    Icon(
+                      _isExpanded
+                          ? Icons.keyboard_arrow_up
+                          : Icons.keyboard_arrow_down,
+                      size: 20,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            // Content
+            if (_isExpanded) ...[
+              Divider(
+                height: 1,
+                color: colorScheme.outline.withValues(alpha: 0.2),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (isHandwriting) ...[
+                      // Show handwriting preview
+                      Container(
+                        height: 100,
+                        decoration: BoxDecoration(
+                          color: colorScheme.surfaceContainerLowest,
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(
+                            color: colorScheme.outline.withValues(alpha: 0.3),
+                          ),
+                        ),
+                        child: Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                Icons.draw,
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                'Handwritten note',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ] else ...[
+                      // Text input
+                      TextField(
+                        controller: _controller,
+                        focusNode: _focusNode,
+                        maxLines: 3,
+                        minLines: 1,
+                        decoration: InputDecoration(
+                          hintText: 'Jot something down...',
+                          hintStyle: TextStyle(
+                            color: colorScheme.onSurfaceVariant.withValues(
+                              alpha: 0.6,
+                            ),
+                          ),
+                          filled: true,
+                          fillColor: colorScheme.surfaceContainerLowest,
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(8),
+                            borderSide: BorderSide(
+                              color: colorScheme.outline.withValues(alpha: 0.3),
+                            ),
+                          ),
+                          enabledBorder: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(8),
+                            borderSide: BorderSide(
+                              color: colorScheme.outline.withValues(alpha: 0.3),
+                            ),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(8),
+                            borderSide: BorderSide(color: colorScheme.primary),
+                          ),
+                          contentPadding: const EdgeInsets.all(12),
+                        ),
+                        onChanged: (_) => _saveNote(),
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: colorScheme.onSurface,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 8),
+                    // Actions
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        if (hasNote) ...[
+                          TextButton.icon(
+                            onPressed: _clearNote,
+                            icon: const Icon(Icons.delete_outline, size: 18),
+                            label: const Text('Clear'),
+                            style: TextButton.styleFrom(
+                              foregroundColor: colorScheme.error,
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 8,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ] else if (hasNote) ...[
+              // Collapsed preview
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 0, 12, 10),
+                child: Text(
+                  isHandwriting
+                      ? '✏️ Handwritten note'
+                      : (note?.content ?? '').length > 50
+                      ? '${(note?.content ?? '').substring(0, 50)}...'
+                      : (note?.content ?? ''),
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/quick_notes/inline_quick_notes.dart
+++ b/lib/components/quick_notes/inline_quick_notes.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:kivixa/components/quick_notes/quick_note_canvas.dart';
 import 'package:kivixa/services/quick_notes/quick_notes_service.dart';
 
 /// A compact inline quick notes widget for the sidebar/browse page.
-/// Shows current quick note and allows editing.
+/// Shows all quick notes side by side with newest on the left.
 class InlineQuickNotes extends StatefulWidget {
   const InlineQuickNotes({super.key});
 
@@ -11,70 +12,56 @@ class InlineQuickNotes extends StatefulWidget {
 }
 
 class _InlineQuickNotesState extends State<InlineQuickNotes> {
-  final _controller = TextEditingController();
-  final _focusNode = FocusNode();
   var _isExpanded = false;
+  var _isAddingNew = false;
+  var _isHandwritingMode = false;
+  final _textController = TextEditingController();
+  final _canvasKey = GlobalKey<QuickNoteCanvasState>();
 
   @override
   void initState() {
     super.initState();
-    _loadCurrentNote();
     QuickNotesService.instance.addListener(_onNotesChanged);
   }
 
   @override
   void dispose() {
     QuickNotesService.instance.removeListener(_onNotesChanged);
-    _controller.dispose();
-    _focusNode.dispose();
+    _textController.dispose();
     super.dispose();
   }
 
   void _onNotesChanged() {
-    if (mounted) {
-      _loadCurrentNote();
-    }
-  }
-
-  void _loadCurrentNote() {
-    final notes = QuickNotesService.instance.activeNotes;
-    if (notes.isNotEmpty) {
-      final note = notes.first;
-      if (!note.isHandwritten && _controller.text != note.content) {
-        _controller.text = note.content;
-      }
-    } else if (_controller.text.isNotEmpty) {
-      _controller.clear();
-    }
     if (mounted) setState(() {});
   }
 
-  void _saveNote() {
-    final text = _controller.text.trim();
-    final notes = QuickNotesService.instance.activeNotes;
+  void _addTextNote() {
+    final text = _textController.text.trim();
+    if (text.isEmpty) return;
 
-    if (text.isNotEmpty) {
-      if (notes.isNotEmpty) {
-        // Update existing note
-        QuickNotesService.instance.updateNote(notes.first.id, content: text);
-      } else {
-        // Create new note
-        QuickNotesService.instance.addNote(content: text);
-      }
-    }
+    QuickNotesService.instance.addNote(content: text);
+    _textController.clear();
+    setState(() => _isAddingNew = false);
   }
 
-  void _clearNote() {
-    QuickNotesService.instance.clearAllNotes();
-    _controller.clear();
-    setState(() {});
+  void _addHandwritingNote() {
+    final canvasState = _canvasKey.currentState;
+    if (canvasState == null || canvasState.data.isEmpty) return;
+
+    QuickNotesService.instance.addNote(
+      content: 'Handwritten note',
+      isHandwritten: true,
+      handwrittenData: canvasState.data.toJsonString(),
+    );
+
+    setState(() => _isAddingNew = false);
   }
 
-  String _getTimeRemaining() {
-    final notes = QuickNotesService.instance.activeNotes;
-    if (notes.isEmpty) return '';
+  void _deleteNote(String id) {
+    QuickNotesService.instance.deleteNote(id);
+  }
 
-    final note = notes.first;
+  String _getTimeRemaining(QuickNote note) {
     final remaining = note.remainingTime(
       QuickNotesService.instance.autoDeleteDuration,
     );
@@ -82,22 +69,20 @@ class _InlineQuickNotesState extends State<InlineQuickNotes> {
     if (remaining == Duration.zero) return 'Expired';
 
     if (remaining.inDays > 0) {
-      return '${remaining.inDays}d left';
+      return '${remaining.inDays}d';
     } else if (remaining.inHours > 0) {
-      return '${remaining.inHours}h left';
+      return '${remaining.inHours}h';
     } else if (remaining.inMinutes > 0) {
-      return '${remaining.inMinutes}m left';
+      return '${remaining.inMinutes}m';
     }
-    return 'Less than 1m';
+    return '<1m';
   }
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = ColorScheme.of(context);
     final notes = QuickNotesService.instance.activeNotes;
-    final hasNote = notes.isNotEmpty;
-    final note = hasNote ? notes.first : null;
-    final isHandwriting = note?.isHandwritten ?? false;
+    final hasNotes = notes.isNotEmpty;
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -114,184 +99,367 @@ class _InlineQuickNotesState extends State<InlineQuickNotes> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             // Header
-            InkWell(
-              onTap: () => setState(() => _isExpanded = !_isExpanded),
-              borderRadius: BorderRadius.vertical(
-                top: const Radius.circular(12),
-                bottom: _isExpanded ? Radius.zero : const Radius.circular(12),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 10,
-                ),
-                child: Row(
-                  children: [
-                    Icon(
-                      Icons.sticky_note_2_outlined,
-                      size: 20,
-                      color: colorScheme.primary,
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        'Quick Note',
-                        style: TextStyle(
-                          fontWeight: FontWeight.w600,
-                          color: colorScheme.onSurface,
-                        ),
-                      ),
-                    ),
-                    if (hasNote) ...[
-                      Text(
-                        _getTimeRemaining(),
-                        style: TextStyle(
-                          fontSize: 11,
-                          color: colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                    ],
-                    Icon(
-                      _isExpanded
-                          ? Icons.keyboard_arrow_up
-                          : Icons.keyboard_arrow_down,
-                      size: 20,
-                      color: colorScheme.onSurfaceVariant,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            // Content
+            _buildHeader(context, hasNotes, notes.length),
+
+            // Collapsed preview
+            if (!_isExpanded && hasNotes)
+              _buildCollapsedPreview(context, notes),
+
+            // Expanded content
             if (_isExpanded) ...[
               Divider(
                 height: 1,
                 color: colorScheme.outline.withValues(alpha: 0.2),
               ),
-              Padding(
-                padding: const EdgeInsets.all(12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    if (isHandwriting) ...[
-                      // Show handwriting preview
-                      Container(
-                        height: 100,
-                        decoration: BoxDecoration(
-                          color: colorScheme.surfaceContainerLowest,
-                          borderRadius: BorderRadius.circular(8),
-                          border: Border.all(
-                            color: colorScheme.outline.withValues(alpha: 0.3),
-                          ),
-                        ),
-                        child: Center(
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Icon(
-                                Icons.draw,
-                                color: colorScheme.onSurfaceVariant,
-                              ),
-                              const SizedBox(height: 4),
-                              Text(
-                                'Handwritten note',
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  color: colorScheme.onSurfaceVariant,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ] else ...[
-                      // Text input
-                      TextField(
-                        controller: _controller,
-                        focusNode: _focusNode,
-                        maxLines: 3,
-                        minLines: 1,
-                        decoration: InputDecoration(
-                          hintText: 'Jot something down...',
-                          hintStyle: TextStyle(
-                            color: colorScheme.onSurfaceVariant.withValues(
-                              alpha: 0.6,
-                            ),
-                          ),
-                          filled: true,
-                          fillColor: colorScheme.surfaceContainerLowest,
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(8),
-                            borderSide: BorderSide(
-                              color: colorScheme.outline.withValues(alpha: 0.3),
-                            ),
-                          ),
-                          enabledBorder: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(8),
-                            borderSide: BorderSide(
-                              color: colorScheme.outline.withValues(alpha: 0.3),
-                            ),
-                          ),
-                          focusedBorder: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(8),
-                            borderSide: BorderSide(color: colorScheme.primary),
-                          ),
-                          contentPadding: const EdgeInsets.all(12),
-                        ),
-                        onChanged: (_) => _saveNote(),
-                        style: TextStyle(
-                          fontSize: 14,
-                          color: colorScheme.onSurface,
-                        ),
-                      ),
-                    ],
-                    const SizedBox(height: 8),
-                    // Actions
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        if (hasNote) ...[
-                          TextButton.icon(
-                            onPressed: _clearNote,
-                            icon: const Icon(Icons.delete_outline, size: 18),
-                            label: const Text('Clear'),
-                            style: TextButton.styleFrom(
-                              foregroundColor: colorScheme.error,
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 8,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ] else if (hasNote) ...[
-              // Collapsed preview
-              Padding(
-                padding: const EdgeInsets.fromLTRB(12, 0, 12, 10),
-                child: Text(
-                  isHandwriting
-                      ? '✏️ Handwritten note'
-                      : (note?.content ?? '').length > 50
-                      ? '${(note?.content ?? '').substring(0, 50)}...'
-                      : (note?.content ?? ''),
-                  style: TextStyle(
-                    fontSize: 12,
-                    color: colorScheme.onSurfaceVariant,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
+              _buildExpandedContent(context, notes),
             ],
           ],
         ),
       ),
     );
+  }
+
+  Widget _buildHeader(BuildContext context, bool hasNotes, int count) {
+    final colorScheme = ColorScheme.of(context);
+
+    return InkWell(
+      onTap: () => setState(() => _isExpanded = !_isExpanded),
+      borderRadius: BorderRadius.vertical(
+        top: const Radius.circular(12),
+        bottom: _isExpanded ? Radius.zero : const Radius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        child: Row(
+          children: [
+            Icon(
+              Icons.sticky_note_2_outlined,
+              size: 20,
+              color: colorScheme.primary,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'Quick Notes',
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+            ),
+            if (hasNotes) ...[
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  '$count',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.onPrimaryContainer,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+            ],
+            Icon(
+              _isExpanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
+              size: 20,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCollapsedPreview(BuildContext context, List<QuickNote> notes) {
+    final colorScheme = ColorScheme.of(context);
+    final previewNote = notes.first;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 10),
+      child: Text(
+        previewNote.isHandwritten
+            ? '✏️ ${notes.length} note${notes.length > 1 ? 's' : ''}'
+            : notes.length > 1
+            ? '${previewNote.content.length > 30 ? '${previewNote.content.substring(0, 30)}...' : previewNote.content} +${notes.length - 1} more'
+            : previewNote.content.length > 50
+            ? '${previewNote.content.substring(0, 50)}...'
+            : previewNote.content,
+        style: TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
+  Widget _buildExpandedContent(BuildContext context, List<QuickNote> notes) {
+    final colorScheme = ColorScheme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Add new note section
+          if (_isAddingNew) ...[
+            _buildAddNoteSection(context),
+            const SizedBox(height: 12),
+          ],
+
+          // Notes horizontal scroll list
+          if (notes.isNotEmpty) ...[
+            SizedBox(
+              height: 140,
+              child: ListView.separated(
+                scrollDirection: Axis.horizontal,
+                itemCount: notes.length,
+                separatorBuilder: (_, _) => const SizedBox(width: 8),
+                itemBuilder: (context, index) {
+                  final note = notes[index];
+                  return _buildNoteCard(context, note);
+                },
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+
+          // Actions row
+          Row(
+            children: [
+              if (!_isAddingNew)
+                FilledButton.tonalIcon(
+                  onPressed: () => setState(() {
+                    _isAddingNew = true;
+                    _isHandwritingMode = false;
+                    _textController.clear();
+                  }),
+                  icon: const Icon(Icons.add, size: 18),
+                  label: const Text('Add Note'),
+                ),
+              const Spacer(),
+              if (notes.isNotEmpty)
+                TextButton.icon(
+                  onPressed: () {
+                    QuickNotesService.instance.clearAllNotes();
+                  },
+                  icon: Icon(
+                    Icons.delete_sweep,
+                    size: 18,
+                    color: colorScheme.error,
+                  ),
+                  label: Text(
+                    'Clear All',
+                    style: TextStyle(color: colorScheme.error),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAddNoteSection(BuildContext context) {
+    final colorScheme = ColorScheme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.primaryContainer.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.primary.withValues(alpha: 0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Mode toggle
+          Row(
+            children: [
+              Expanded(
+                child: SegmentedButton<bool>(
+                  segments: const [
+                    ButtonSegment(
+                      value: false,
+                      icon: Icon(Icons.text_fields, size: 16),
+                      label: Text('Text'),
+                    ),
+                    ButtonSegment(
+                      value: true,
+                      icon: Icon(Icons.draw, size: 16),
+                      label: Text('Draw'),
+                    ),
+                  ],
+                  selected: {_isHandwritingMode},
+                  onSelectionChanged: (value) {
+                    setState(() => _isHandwritingMode = value.first);
+                  },
+                  style: const ButtonStyle(
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => setState(() => _isAddingNew = false),
+                tooltip: 'Cancel',
+                visualDensity: VisualDensity.compact,
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+
+          // Input area
+          if (_isHandwritingMode) ...[
+            QuickNoteCanvas(
+              key: _canvasKey,
+              height: 120,
+              strokeColor: colorScheme.onSurface,
+              strokeWidth: 2.0,
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                TextButton.icon(
+                  onPressed: () => _canvasKey.currentState?.clear(),
+                  icon: const Icon(Icons.clear, size: 16),
+                  label: const Text('Clear'),
+                ),
+                const Spacer(),
+                FilledButton.icon(
+                  onPressed: _addHandwritingNote,
+                  icon: const Icon(Icons.check, size: 16),
+                  label: const Text('Save'),
+                ),
+              ],
+            ),
+          ] else ...[
+            TextField(
+              controller: _textController,
+              maxLines: 2,
+              minLines: 1,
+              autofocus: true,
+              decoration: InputDecoration(
+                hintText: 'Jot something down...',
+                filled: true,
+                fillColor: colorScheme.surface,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide.none,
+                ),
+                contentPadding: const EdgeInsets.all(12),
+              ),
+              onSubmitted: (_) => _addTextNote(),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                FilledButton.icon(
+                  onPressed: _textController.text.trim().isNotEmpty
+                      ? _addTextNote
+                      : null,
+                  icon: const Icon(Icons.check, size: 16),
+                  label: const Text('Save'),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNoteCard(BuildContext context, QuickNote note) {
+    final colorScheme = ColorScheme.of(context);
+
+    return Container(
+      width: 180,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: colorScheme.outline.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header with time and delete
+          Row(
+            children: [
+              Icon(
+                note.isHandwritten ? Icons.draw : Icons.notes,
+                size: 14,
+                color: colorScheme.primary,
+              ),
+              const SizedBox(width: 4),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                decoration: BoxDecoration(
+                  color: colorScheme.secondaryContainer,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  _getTimeRemaining(note),
+                  style: TextStyle(
+                    fontSize: 10,
+                    color: colorScheme.onSecondaryContainer,
+                  ),
+                ),
+              ),
+              const Spacer(),
+              InkWell(
+                onTap: () => _deleteNote(note.id),
+                borderRadius: BorderRadius.circular(12),
+                child: Padding(
+                  padding: const EdgeInsets.all(2),
+                  child: Icon(
+                    Icons.close,
+                    size: 16,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+
+          // Content
+          Expanded(
+            child: note.isHandwritten
+                ? _buildHandwritingPreview(context, note)
+                : Text(
+                    note.content,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: colorScheme.onSurface,
+                    ),
+                    maxLines: 5,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHandwritingPreview(BuildContext context, QuickNote note) {
+    if (note.handwrittenData == null) {
+      return const Center(child: Icon(Icons.draw, size: 32));
+    }
+
+    try {
+      final data = QuickNoteHandwritingData.fromJsonString(
+        note.handwrittenData!,
+      );
+      return QuickNoteHandwritingPreview(data: data, height: 80);
+    } catch (e) {
+      return const Center(child: Icon(Icons.draw, size: 32));
+    }
   }
 }

--- a/lib/components/quick_notes/quick_note_canvas.dart
+++ b/lib/components/quick_notes/quick_note_canvas.dart
@@ -1,0 +1,319 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+/// A simple point with pressure for handwriting
+class QuickNotePoint {
+  const QuickNotePoint(this.x, this.y, [this.pressure = 1.0]);
+
+  final double x;
+  final double y;
+  final double pressure;
+
+  Map<String, dynamic> toJson() => {'x': x, 'y': y, 'p': pressure};
+
+  factory QuickNotePoint.fromJson(Map<String, dynamic> json) {
+    return QuickNotePoint(
+      (json['x'] as num).toDouble(),
+      (json['y'] as num).toDouble(),
+      (json['p'] as num?)?.toDouble() ?? 1.0,
+    );
+  }
+
+  Offset toOffset() => Offset(x, y);
+}
+
+/// A single stroke in a quick note
+class QuickNoteStroke {
+  QuickNoteStroke({
+    required this.points,
+    this.color = Colors.black,
+    this.strokeWidth = 2.0,
+  });
+
+  final List<QuickNotePoint> points;
+  final Color color;
+  final double strokeWidth;
+
+  Map<String, dynamic> toJson() => {
+    'points': points.map((p) => p.toJson()).toList(),
+    'color': color.toARGB32(),
+    'strokeWidth': strokeWidth,
+  };
+
+  factory QuickNoteStroke.fromJson(Map<String, dynamic> json) {
+    return QuickNoteStroke(
+      points: (json['points'] as List)
+          .map((p) => QuickNotePoint.fromJson(p as Map<String, dynamic>))
+          .toList(),
+      color: Color(json['color'] as int),
+      strokeWidth: (json['strokeWidth'] as num?)?.toDouble() ?? 2.0,
+    );
+  }
+
+  Path toPath() {
+    if (points.isEmpty) return Path();
+
+    final path = Path();
+    path.moveTo(points.first.x, points.first.y);
+
+    for (var i = 1; i < points.length; i++) {
+      path.lineTo(points[i].x, points[i].y);
+    }
+
+    return path;
+  }
+}
+
+/// Data model for quick note handwriting
+class QuickNoteHandwritingData {
+  QuickNoteHandwritingData({List<QuickNoteStroke>? strokes})
+    : strokes = strokes ?? [];
+
+  final List<QuickNoteStroke> strokes;
+
+  String toJsonString() => jsonEncode(toJson());
+
+  Map<String, dynamic> toJson() => {
+    'strokes': strokes.map((s) => s.toJson()).toList(),
+  };
+
+  factory QuickNoteHandwritingData.fromJsonString(String json) {
+    return QuickNoteHandwritingData.fromJson(
+      jsonDecode(json) as Map<String, dynamic>,
+    );
+  }
+
+  factory QuickNoteHandwritingData.fromJson(Map<String, dynamic> json) {
+    return QuickNoteHandwritingData(
+      strokes:
+          (json['strokes'] as List?)
+              ?.map((s) => QuickNoteStroke.fromJson(s as Map<String, dynamic>))
+              .toList() ??
+          [],
+    );
+  }
+
+  bool get isEmpty => strokes.isEmpty;
+  bool get isNotEmpty => strokes.isNotEmpty;
+}
+
+/// A simple canvas for quick handwritten notes
+class QuickNoteCanvas extends StatefulWidget {
+  const QuickNoteCanvas({
+    super.key,
+    this.initialData,
+    this.onChanged,
+    this.height = 150,
+    this.strokeColor,
+    this.strokeWidth = 2.0,
+    this.backgroundColor,
+    this.readOnly = false,
+  });
+
+  final QuickNoteHandwritingData? initialData;
+  final ValueChanged<QuickNoteHandwritingData>? onChanged;
+  final double height;
+  final Color? strokeColor;
+  final double strokeWidth;
+  final Color? backgroundColor;
+  final bool readOnly;
+
+  @override
+  State<QuickNoteCanvas> createState() => QuickNoteCanvasState();
+}
+
+class QuickNoteCanvasState extends State<QuickNoteCanvas> {
+  late QuickNoteHandwritingData _data;
+  QuickNoteStroke? _currentStroke;
+
+  @override
+  void initState() {
+    super.initState();
+    _data = widget.initialData ?? QuickNoteHandwritingData();
+  }
+
+  QuickNoteHandwritingData get data => _data;
+
+  void clear() {
+    setState(() {
+      _data = QuickNoteHandwritingData();
+      _currentStroke = null;
+    });
+    widget.onChanged?.call(_data);
+  }
+
+  void _onPanStart(DragStartDetails details) {
+    if (widget.readOnly) return;
+
+    final colorScheme = ColorScheme.of(context);
+    final point = QuickNotePoint(
+      details.localPosition.dx,
+      details.localPosition.dy,
+    );
+
+    setState(() {
+      _currentStroke = QuickNoteStroke(
+        points: [point],
+        color: widget.strokeColor ?? colorScheme.onSurface,
+        strokeWidth: widget.strokeWidth,
+      );
+    });
+  }
+
+  void _onPanUpdate(DragUpdateDetails details) {
+    if (widget.readOnly || _currentStroke == null) return;
+
+    final point = QuickNotePoint(
+      details.localPosition.dx,
+      details.localPosition.dy,
+    );
+
+    setState(() {
+      _currentStroke!.points.add(point);
+    });
+  }
+
+  void _onPanEnd(DragEndDetails details) {
+    if (widget.readOnly || _currentStroke == null) return;
+
+    setState(() {
+      _data.strokes.add(_currentStroke!);
+      _currentStroke = null;
+    });
+
+    widget.onChanged?.call(_data);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = ColorScheme.of(context);
+
+    return GestureDetector(
+      onPanStart: _onPanStart,
+      onPanUpdate: _onPanUpdate,
+      onPanEnd: _onPanEnd,
+      child: Container(
+        height: widget.height,
+        decoration: BoxDecoration(
+          color: widget.backgroundColor ?? colorScheme.surfaceContainerLowest,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: colorScheme.outline.withValues(alpha: 0.3)),
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(7),
+          child: CustomPaint(
+            painter: _QuickNotePainter(
+              strokes: _data.strokes,
+              currentStroke: _currentStroke,
+              defaultColor: widget.strokeColor ?? colorScheme.onSurface,
+            ),
+            size: Size.infinite,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _QuickNotePainter extends CustomPainter {
+  _QuickNotePainter({
+    required this.strokes,
+    this.currentStroke,
+    required this.defaultColor,
+  });
+
+  final List<QuickNoteStroke> strokes;
+  final QuickNoteStroke? currentStroke;
+  final Color defaultColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Draw completed strokes
+    for (final stroke in strokes) {
+      _drawStroke(canvas, stroke);
+    }
+
+    // Draw current stroke
+    if (currentStroke != null) {
+      _drawStroke(canvas, currentStroke!);
+    }
+  }
+
+  void _drawStroke(Canvas canvas, QuickNoteStroke stroke) {
+    if (stroke.points.isEmpty) return;
+
+    final paint = Paint()
+      ..color = stroke.color
+      ..strokeWidth = stroke.strokeWidth
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..style = PaintingStyle.stroke;
+
+    if (stroke.points.length == 1) {
+      // Single point - draw a dot
+      canvas.drawCircle(
+        stroke.points.first.toOffset(),
+        stroke.strokeWidth / 2,
+        paint..style = PaintingStyle.fill,
+      );
+      return;
+    }
+
+    // Draw the path
+    final path = stroke.toPath();
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _QuickNotePainter oldDelegate) {
+    return strokes != oldDelegate.strokes ||
+        currentStroke != oldDelegate.currentStroke;
+  }
+}
+
+/// A read-only preview of handwriting data
+class QuickNoteHandwritingPreview extends StatelessWidget {
+  const QuickNoteHandwritingPreview({
+    super.key,
+    required this.data,
+    this.height = 60,
+    this.backgroundColor,
+  });
+
+  final QuickNoteHandwritingData data;
+  final double height;
+  final Color? backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = ColorScheme.of(context);
+
+    return Container(
+      height: height,
+      decoration: BoxDecoration(
+        color: backgroundColor ?? colorScheme.surfaceContainerLowest,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outline.withValues(alpha: 0.3)),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(7),
+        child: FittedBox(
+          fit: BoxFit.contain,
+          alignment: Alignment.center,
+          child: SizedBox(
+            width: 300,
+            height: 150,
+            child: CustomPaint(
+              painter: _QuickNotePainter(
+                strokes: data.strokes,
+                currentStroke: null,
+                defaultColor: colorScheme.onSurface,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -12,6 +12,7 @@ import 'package:kivixa/components/home/new_note_button.dart';
 import 'package:kivixa/components/home/no_files.dart';
 import 'package:kivixa/components/home/path_components.dart';
 import 'package:kivixa/components/home/rename_note_button.dart';
+import 'package:kivixa/components/quick_notes/inline_quick_notes.dart';
 import 'package:kivixa/data/file_manager/file_manager.dart';
 import 'package:kivixa/data/routes.dart';
 import 'package:kivixa/i18n/strings.g.dart';
@@ -435,6 +436,8 @@ class _BrowsePageState extends State<BrowsePage> {
                     ],
                   ],
                 ),
+                // Quick Notes section
+                const SliverToBoxAdapter(child: InlineQuickNotes()),
                 SliverToBoxAdapter(
                   child: PathComponents(
                     path,

--- a/lib/services/overlay/overlay_controller.dart
+++ b/lib/services/overlay/overlay_controller.dart
@@ -170,6 +170,17 @@ class OverlayController extends ChangeNotifier {
         isActive: () => isToolWindowOpen('clock'),
       ),
     );
+    registerTool(
+      OverlayTool(
+        id: 'quick_notes',
+        icon: Icons.sticky_note_2_rounded,
+        label: 'Quick Notes',
+        onTap: () => isToolWindowOpen('quick_notes')
+            ? closeToolWindow('quick_notes')
+            : openToolWindow('quick_notes'),
+        isActive: () => isToolWindowOpen('quick_notes'),
+      ),
+    );
   }
 
   // ============================================================

--- a/lib/services/productivity/chained_routine_service.dart
+++ b/lib/services/productivity/chained_routine_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -84,14 +85,14 @@ class ChainedRoutine {
   int get totalMinutes => totalDuration.inMinutes;
 
   /// Morning routine preset
-  static final morningRoutine = ChainedRoutine(
+  static const morningRoutine = ChainedRoutine(
     id: 'morning_routine',
     name: 'Morning Routine',
     icon: Icons.wb_sunny,
-    color: const Color(0xFFFF9800),
+    color: Color(0xFFFF9800),
     description: 'Start your day right',
     isDefault: true,
-    blocks: const [
+    blocks: [
       RoutineBlock(
         name: 'Meditate',
         durationMinutes: 10,
@@ -124,14 +125,14 @@ class ChainedRoutine {
   );
 
   /// Evening wind-down routine
-  static final eveningRoutine = ChainedRoutine(
+  static const eveningRoutine = ChainedRoutine(
     id: 'evening_routine',
     name: 'Evening Wind-Down',
     icon: Icons.nights_stay,
-    color: const Color(0xFF673AB7),
+    color: Color(0xFF673AB7),
     description: 'Prepare for restful sleep',
     isDefault: true,
-    blocks: const [
+    blocks: [
       RoutineBlock(
         name: 'Review Day',
         durationMinutes: 10,
@@ -164,14 +165,14 @@ class ChainedRoutine {
   );
 
   /// Study session routine
-  static final studySession = ChainedRoutine(
+  static const studySession = ChainedRoutine(
     id: 'study_session',
     name: 'Study Session',
     icon: Icons.school,
-    color: const Color(0xFF2196F3),
+    color: Color(0xFF2196F3),
     description: 'Structured learning blocks',
     isDefault: true,
-    blocks: const [
+    blocks: [
       RoutineBlock(
         name: 'Review Notes',
         durationMinutes: 15,
@@ -204,14 +205,14 @@ class ChainedRoutine {
   );
 
   /// Creative work session
-  static final creativeSession = ChainedRoutine(
+  static const creativeSession = ChainedRoutine(
     id: 'creative_session',
     name: 'Creative Session',
     icon: Icons.palette,
-    color: const Color(0xFFE91E63),
+    color: Color(0xFFE91E63),
     description: 'Structured creative work',
     isDefault: true,
-    blocks: const [
+    blocks: [
       RoutineBlock(
         name: 'Warm Up',
         durationMinutes: 10,
@@ -244,14 +245,14 @@ class ChainedRoutine {
   );
 
   /// Work sprint routine
-  static final workSprint = ChainedRoutine(
+  static const workSprint = ChainedRoutine(
     id: 'work_sprint',
     name: 'Work Sprint',
     icon: Icons.flash_on,
-    color: const Color(0xFFF44336),
+    color: Color(0xFFF44336),
     description: 'High-intensity work blocks',
     isDefault: true,
-    blocks: const [
+    blocks: [
       RoutineBlock(
         name: 'Plan Sprint',
         durationMinutes: 5,
@@ -353,7 +354,7 @@ class ChainedRoutineService extends ChangeNotifier {
 
   // Routine state
   ChainedRoutine? _currentRoutine;
-  int _currentBlockIndex = 0;
+  var _currentBlockIndex = 0;
   RoutineState _state = RoutineState.idle;
   Duration _remainingTime = Duration.zero;
   Timer? _timer;
@@ -422,18 +423,21 @@ class ChainedRoutineService extends ChangeNotifier {
   Future<void> initialize() async {
     if (_initialized) return;
 
-    _notifications = FlutterLocalNotificationsPlugin();
-    const androidSettings = AndroidInitializationSettings(
-      '@mipmap/ic_launcher',
-    );
-    const initSettings = InitializationSettings(android: androidSettings);
-
-    try {
-      await _notifications?.initialize(initSettings);
-    } catch (e) {
-      debugPrint(
-        'Failed to initialize notifications for ChainedRoutineService: $e',
+    // Only initialize notifications on supported platforms
+    if (Platform.isAndroid || Platform.isIOS) {
+      _notifications = FlutterLocalNotificationsPlugin();
+      const androidSettings = AndroidInitializationSettings(
+        '@mipmap/ic_launcher',
       );
+      const initSettings = InitializationSettings(android: androidSettings);
+
+      try {
+        await _notifications?.initialize(initSettings);
+      } catch (e) {
+        debugPrint(
+          'Failed to initialize notifications for ChainedRoutineService: $e',
+        );
+      }
     }
 
     await _loadRoutines();
@@ -529,7 +533,7 @@ class ChainedRoutineService extends ChangeNotifier {
       _state = RoutineState.completed;
       _showNotification(
         title: '${_currentRoutine!.name} Complete! 🎉',
-        body: 'Great job! You completed all ${totalBlocks} blocks.',
+        body: 'Great job! You completed all $totalBlocks blocks.',
       );
       notifyListeners();
       return;

--- a/lib/services/productivity/multi_timer_service.dart
+++ b/lib/services/productivity/multi_timer_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -27,9 +28,9 @@ class SecondaryTimer {
 
   Duration _remainingTime = Duration.zero;
   Timer? _timer;
-  bool _isRunning = false;
-  bool _isPaused = false;
-  bool _isCompleted = false;
+  var _isRunning = false;
+  var _isPaused = false;
+  var _isCompleted = false;
 
   Duration get remainingTime => _remainingTime;
   bool get isRunning => _isRunning;
@@ -285,18 +286,21 @@ class MultiTimerService extends ChangeNotifier {
   Future<void> initialize() async {
     if (_initialized) return;
 
-    _notifications = FlutterLocalNotificationsPlugin();
-    const androidSettings = AndroidInitializationSettings(
-      '@mipmap/ic_launcher',
-    );
-    const initSettings = InitializationSettings(android: androidSettings);
-
-    try {
-      await _notifications?.initialize(initSettings);
-    } catch (e) {
-      debugPrint(
-        'Failed to initialize notifications for MultiTimerService: $e',
+    // Only initialize notifications on supported platforms
+    if (Platform.isAndroid || Platform.isIOS) {
+      _notifications = FlutterLocalNotificationsPlugin();
+      const androidSettings = AndroidInitializationSettings(
+        '@mipmap/ic_launcher',
       );
+      const initSettings = InitializationSettings(android: androidSettings);
+
+      try {
+        await _notifications?.initialize(initSettings);
+      } catch (e) {
+        debugPrint(
+          'Failed to initialize notifications for MultiTimerService: $e',
+        );
+      }
     }
 
     await _loadTimers();

--- a/lib/services/productivity/productivity_timer_service.dart
+++ b/lib/services/productivity/productivity_timer_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -331,6 +332,12 @@ class ProductivityTimerService extends ChangeNotifier {
 
   /// Initialize notifications
   Future<void> _initializeNotifications() async {
+    // Skip notifications on unsupported platforms
+    if (!Platform.isAndroid && !Platform.isIOS) {
+      _notificationsInitialized = false;
+      return;
+    }
+
     _notifications = FlutterLocalNotificationsPlugin();
 
     const androidSettings = AndroidInitializationSettings(

--- a/lib/services/quick_notes/quick_notes_service.dart
+++ b/lib/services/quick_notes/quick_notes_service.dart
@@ -1,0 +1,300 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// A quick note that will be auto-deleted after a certain time.
+class QuickNote {
+  QuickNote({
+    required this.id,
+    required this.content,
+    required this.createdAt,
+    this.isHandwritten = false,
+    this.handwrittenData,
+  });
+
+  final String id;
+  String content;
+  final DateTime createdAt;
+  final bool isHandwritten;
+  final String? handwrittenData;
+
+  /// Time remaining before auto-delete
+  Duration remainingTime(Duration autoDeleteDuration) {
+    final expiresAt = createdAt.add(autoDeleteDuration);
+    final remaining = expiresAt.difference(DateTime.now());
+    return remaining.isNegative ? Duration.zero : remaining;
+  }
+
+  /// Whether this note has expired
+  bool isExpired(Duration autoDeleteDuration) {
+    return remainingTime(autoDeleteDuration) == Duration.zero;
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'content': content,
+    'createdAt': createdAt.toIso8601String(),
+    'isHandwritten': isHandwritten,
+    'handwrittenData': handwrittenData,
+  };
+
+  factory QuickNote.fromJson(Map<String, dynamic> json) {
+    return QuickNote(
+      id: json['id'] as String,
+      content: json['content'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      isHandwritten: json['isHandwritten'] as bool? ?? false,
+      handwrittenData: json['handwrittenData'] as String?,
+    );
+  }
+
+  QuickNote copyWith({
+    String? id,
+    String? content,
+    DateTime? createdAt,
+    bool? isHandwritten,
+    String? handwrittenData,
+  }) {
+    return QuickNote(
+      id: id ?? this.id,
+      content: content ?? this.content,
+      createdAt: createdAt ?? this.createdAt,
+      isHandwritten: isHandwritten ?? this.isHandwritten,
+      handwrittenData: handwrittenData ?? this.handwrittenData,
+    );
+  }
+}
+
+/// Service for managing quick notes with auto-delete functionality.
+class QuickNotesService extends ChangeNotifier {
+  QuickNotesService._();
+
+  static final _instance = QuickNotesService._();
+  static QuickNotesService get instance => _instance;
+
+  // Settings
+  var _autoDeleteDuration = const Duration(hours: 24);
+  var _autoDeleteEnabled = true;
+
+  // State
+  final List<QuickNote> _notes = [];
+  Timer? _cleanupTimer;
+  var _initialized = false;
+
+  // Persistence keys
+  static const _notesKey = 'quick_notes';
+  static const _settingsKey = 'quick_notes_settings';
+
+  // Getters
+  List<QuickNote> get notes => List.unmodifiable(_notes);
+  Duration get autoDeleteDuration => _autoDeleteDuration;
+  bool get autoDeleteEnabled => _autoDeleteEnabled;
+  bool get isEmpty => _notes.isEmpty;
+  int get count => _notes.length;
+
+  /// Get only non-expired notes
+  List<QuickNote> get activeNotes {
+    if (!_autoDeleteEnabled) return notes;
+    return _notes
+        .where((note) => !note.isExpired(_autoDeleteDuration))
+        .toList();
+  }
+
+  /// Initialize the service
+  Future<void> initialize() async {
+    if (_initialized) return;
+
+    await _loadSettings();
+    await _loadNotes();
+    _startCleanupTimer();
+    _initialized = true;
+  }
+
+  /// Add a new quick note
+  QuickNote addNote({
+    required String content,
+    bool isHandwritten = false,
+    String? handwrittenData,
+  }) {
+    final note = QuickNote(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      content: content,
+      createdAt: DateTime.now(),
+      isHandwritten: isHandwritten,
+      handwrittenData: handwrittenData,
+    );
+    _notes.insert(0, note);
+    _saveNotes();
+    notifyListeners();
+    return note;
+  }
+
+  /// Update an existing note
+  void updateNote(String id, {String? content, String? handwrittenData}) {
+    final index = _notes.indexWhere((note) => note.id == id);
+    if (index == -1) return;
+
+    _notes[index] = _notes[index].copyWith(
+      content: content,
+      handwrittenData: handwrittenData,
+    );
+    _saveNotes();
+    notifyListeners();
+  }
+
+  /// Delete a specific note
+  void deleteNote(String id) {
+    _notes.removeWhere((note) => note.id == id);
+    _saveNotes();
+    notifyListeners();
+  }
+
+  /// Clear all notes
+  void clearAllNotes() {
+    _notes.clear();
+    _saveNotes();
+    notifyListeners();
+  }
+
+  /// Clean up expired notes
+  void cleanupExpiredNotes() {
+    if (!_autoDeleteEnabled) return;
+
+    final before = _notes.length;
+    _notes.removeWhere((note) => note.isExpired(_autoDeleteDuration));
+
+    if (_notes.length != before) {
+      _saveNotes();
+      notifyListeners();
+    }
+  }
+
+  /// Set auto-delete duration
+  void setAutoDeleteDuration(Duration duration) {
+    _autoDeleteDuration = duration;
+    _saveSettings();
+    notifyListeners();
+  }
+
+  /// Enable or disable auto-delete
+  void setAutoDeleteEnabled(bool enabled) {
+    _autoDeleteEnabled = enabled;
+    _saveSettings();
+    notifyListeners();
+  }
+
+  /// Start the cleanup timer
+  void _startCleanupTimer() {
+    _cleanupTimer?.cancel();
+    _cleanupTimer = Timer.periodic(const Duration(minutes: 1), (_) {
+      cleanupExpiredNotes();
+    });
+  }
+
+  /// Load notes from storage
+  Future<void> _loadNotes() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final notesJson = prefs.getString(_notesKey);
+      if (notesJson == null) return;
+
+      final notesList = jsonDecode(notesJson) as List;
+      _notes.clear();
+      _notes.addAll(
+        notesList.map(
+          (json) => QuickNote.fromJson(json as Map<String, dynamic>),
+        ),
+      );
+
+      // Clean up expired notes on load
+      cleanupExpiredNotes();
+    } catch (e) {
+      debugPrint('Failed to load quick notes: $e');
+    }
+  }
+
+  /// Save notes to storage
+  Future<void> _saveNotes() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final notesJson = jsonEncode(_notes.map((n) => n.toJson()).toList());
+      await prefs.setString(_notesKey, notesJson);
+    } catch (e) {
+      debugPrint('Failed to save quick notes: $e');
+    }
+  }
+
+  /// Load settings from storage
+  Future<void> _loadSettings() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final settingsJson = prefs.getString(_settingsKey);
+      if (settingsJson == null) return;
+
+      final settings = jsonDecode(settingsJson) as Map<String, dynamic>;
+      _autoDeleteDuration = Duration(
+        minutes: settings['autoDeleteMinutes'] as int? ?? 1440,
+      );
+      _autoDeleteEnabled = settings['autoDeleteEnabled'] as bool? ?? true;
+    } catch (e) {
+      debugPrint('Failed to load quick notes settings: $e');
+    }
+  }
+
+  /// Save settings to storage
+  Future<void> _saveSettings() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final settingsJson = jsonEncode({
+        'autoDeleteMinutes': _autoDeleteDuration.inMinutes,
+        'autoDeleteEnabled': _autoDeleteEnabled,
+      });
+      await prefs.setString(_settingsKey, settingsJson);
+    } catch (e) {
+      debugPrint('Failed to save quick notes settings: $e');
+    }
+  }
+
+  @override
+  void dispose() {
+    _cleanupTimer?.cancel();
+    super.dispose();
+  }
+}
+
+/// Preset durations for auto-delete
+class QuickNoteAutoDeletePresets {
+  static const fifteenMinutes = Duration(minutes: 15);
+  static const thirtyMinutes = Duration(minutes: 30);
+  static const oneHour = Duration(hours: 1);
+  static const fourHours = Duration(hours: 4);
+  static const twelveHours = Duration(hours: 12);
+  static const oneDay = Duration(hours: 24);
+  static const threeDays = Duration(days: 3);
+  static const oneWeek = Duration(days: 7);
+
+  static const presets = <Duration>[
+    fifteenMinutes,
+    thirtyMinutes,
+    oneHour,
+    fourHours,
+    twelveHours,
+    oneDay,
+    threeDays,
+    oneWeek,
+  ];
+
+  static String formatDuration(Duration duration) {
+    if (duration.inDays >= 7) {
+      return '${duration.inDays ~/ 7} week${duration.inDays >= 14 ? 's' : ''}';
+    } else if (duration.inDays >= 1) {
+      return '${duration.inDays} day${duration.inDays > 1 ? 's' : ''}';
+    } else if (duration.inHours >= 1) {
+      return '${duration.inHours} hour${duration.inHours > 1 ? 's' : ''}';
+    } else {
+      return '${duration.inMinutes} minute${duration.inMinutes > 1 ? 's' : ''}';
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: "direct main"
     description:
       name: background_downloader
-      sha256: a3b340e42bc45598918944e378dc6a05877e587fcd0e1b8d2ea26339de87bdf9
+      sha256: efe41340f6518449f6c5f116d9bcecc97bbff7708efe47d7a645478117ce15fd
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "9.4.1"
   barcode:
     dependency: transitive
     description:
@@ -1495,18 +1495,18 @@ packages:
     dependency: "direct main"
     description:
       name: pdfrx
-      sha256: "40ab38d80af88ab58e9bab63a706a69f18f516fd0f1433f71833af236b159f42"
+      sha256: c9717a8e233fd92ccacd29088e16ae1ba155ebff9ff7a08fdb711820ea6199ff
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.16"
+    version: "2.2.17"
   pdfrx_engine:
     dependency: transitive
     description:
       name: pdfrx_engine
-      sha256: "6b7810d0fdd467760bf8e0afafb67140971bf297c9f9b12add5b2033bb55064f"
+      sha256: e4e942bda9f3876d34729fab8e0c5185b9384614929d82bd6efa8ef2a31b0be3
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5"
+    version: "0.3.6"
   percent_indicator:
     dependency: "direct main"
     description:

--- a/test/chained_routine_service_test.dart
+++ b/test/chained_routine_service_test.dart
@@ -89,10 +89,10 @@ void main() {
 
   group('ChainedRoutine', () {
     test('creates with required properties', () {
-      final routine = ChainedRoutine(
+      const routine = ChainedRoutine(
         id: 'test_routine',
         name: 'Test Routine',
-        blocks: const [RoutineBlock(name: 'Block 1', durationMinutes: 10)],
+        blocks: [RoutineBlock(name: 'Block 1', durationMinutes: 10)],
       );
 
       expect(routine.id, 'test_routine');
@@ -104,10 +104,10 @@ void main() {
     });
 
     test('creates default routine', () {
-      final routine = ChainedRoutine(
+      const routine = ChainedRoutine(
         id: 'default',
         name: 'Default',
-        blocks: const [],
+        blocks: [],
         isDefault: true,
       );
 
@@ -115,10 +115,10 @@ void main() {
     });
 
     test('totalDuration sums all blocks', () {
-      final routine = ChainedRoutine(
+      const routine = ChainedRoutine(
         id: 'test',
         name: 'Test',
-        blocks: const [
+        blocks: [
           RoutineBlock(name: 'B1', durationMinutes: 10),
           RoutineBlock(name: 'B2', durationMinutes: 15),
           RoutineBlock(name: 'B3', durationMinutes: 5),
@@ -129,10 +129,10 @@ void main() {
     });
 
     test('totalMinutes returns correct value', () {
-      final routine = ChainedRoutine(
+      const routine = ChainedRoutine(
         id: 'test',
         name: 'Test',
-        blocks: const [
+        blocks: [
           RoutineBlock(name: 'B1', durationMinutes: 10),
           RoutineBlock(name: 'B2', durationMinutes: 15),
         ],
@@ -142,12 +142,12 @@ void main() {
     });
 
     test('toJson and fromJson work correctly', () {
-      final routine = ChainedRoutine(
+      const routine = ChainedRoutine(
         id: 'test',
         name: 'Test Routine',
         description: 'A test routine',
         icon: Icons.star,
-        blocks: const [RoutineBlock(name: 'Block 1', durationMinutes: 10)],
+        blocks: [RoutineBlock(name: 'Block 1', durationMinutes: 10)],
         isDefault: false,
       );
       final json = routine.toJson();
@@ -162,10 +162,10 @@ void main() {
     });
 
     test('copyWith creates modified copy', () {
-      final routine = ChainedRoutine(
+      const routine = ChainedRoutine(
         id: 'original',
         name: 'Original',
-        blocks: const [],
+        blocks: [],
       );
       final copy = routine.copyWith(
         name: 'Modified',
@@ -180,35 +180,35 @@ void main() {
 
   group('Default Routines', () {
     test('morning routine exists', () {
-      final routine = ChainedRoutine.morningRoutine;
+      const routine = ChainedRoutine.morningRoutine;
       expect(routine.name, 'Morning Routine');
       expect(routine.blocks.isNotEmpty, true);
       expect(routine.isDefault, true);
     });
 
     test('evening routine exists', () {
-      final routine = ChainedRoutine.eveningRoutine;
+      const routine = ChainedRoutine.eveningRoutine;
       expect(routine.name, 'Evening Wind-Down');
       expect(routine.blocks.isNotEmpty, true);
       expect(routine.isDefault, true);
     });
 
     test('study session exists', () {
-      final routine = ChainedRoutine.studySession;
+      const routine = ChainedRoutine.studySession;
       expect(routine.name, 'Study Session');
       expect(routine.blocks.isNotEmpty, true);
       expect(routine.isDefault, true);
     });
 
     test('creative session exists', () {
-      final routine = ChainedRoutine.creativeSession;
+      const routine = ChainedRoutine.creativeSession;
       expect(routine.name, 'Creative Session');
       expect(routine.blocks.isNotEmpty, true);
       expect(routine.isDefault, true);
     });
 
     test('work sprint exists', () {
-      final routine = ChainedRoutine.workSprint;
+      const routine = ChainedRoutine.workSprint;
       expect(routine.name, 'Work Sprint');
       expect(routine.blocks.isNotEmpty, true);
       expect(routine.isDefault, true);
@@ -278,7 +278,7 @@ void main() {
       final service = ChainedRoutineService.instance;
       service.stop();
 
-      final routine = ChainedRoutine.morningRoutine;
+      const routine = ChainedRoutine.morningRoutine;
       service.startRoutine(routine);
 
       expect(service.currentRoutine?.id, routine.id);

--- a/test/productivity_timer_service_test.dart
+++ b/test/productivity_timer_service_test.dart
@@ -97,7 +97,7 @@ void main() {
     });
 
     test('toJson and fromJson work correctly', () {
-      final tag = TimerContextTag(
+      const tag = TimerContextTag(
         id: 'test_tag',
         name: 'Test Tag',
         icon: Icons.star,
@@ -112,19 +112,19 @@ void main() {
     });
 
     test('equality works correctly', () {
-      final tag1 = TimerContextTag(
+      const tag1 = TimerContextTag(
         id: 'test',
         name: 'Test',
         icon: Icons.star,
         color: Colors.blue,
       );
-      final tag2 = TimerContextTag(
+      const tag2 = TimerContextTag(
         id: 'test',
         name: 'Different Name',
         icon: Icons.circle,
         color: Colors.red,
       );
-      final tag3 = TimerContextTag(
+      const tag3 = TimerContextTag(
         id: 'other',
         name: 'Test',
         icon: Icons.star,
@@ -176,7 +176,7 @@ void main() {
     });
 
     test('toJson and fromJson work correctly', () {
-      final preset = QuickPreset.code;
+      const preset = QuickPreset.code;
       final json = preset.toJson();
       final restored = QuickPreset.fromJson(json);
 


### PR DESCRIPTION
## Summary
Adds handwriting support to quick notes and enables multiple notes display.

## Changes
- Add QuickNoteCanvas component for handwriting input with stroke serialization
- Update FloatingQuickNotes with handwriting mode toggle
- Rewrite InlineQuickNotes to display multiple notes side-by-side horizontally (newest leftmost)
- Fix Windows notification initialization with platform-specific settings
- Add Windows notification support to productivity timer services

## Testing
- flutter analyze: No issues found