### PR TITLE
Fix Flutter version in performance workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.24.0'
+        flutter-version: '3.35.0'
         channel: 'stable'
         
     - name: Get dependencies


### PR DESCRIPTION
Fixes the GitHub Actions workflow error by updating Flutter version from 3.24.0 to 3.35.0.

The project requires:
- Dart SDK: >=3.9.0 <4.0.0
- Flutter: >=3.35.0

Flutter 3.24.0 comes with Dart 3.5.0 which doesn't meet the SDK requirement.