### PR TITLE
⚡ Bolt: Optimize EmbeddedFileBrowser list rendering and I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-11 - File Browser List Rendering & I/O Bottlenecks
+**Learning:** In Flutter, using `ListView` with a large number of children created synchronously forces the instantiation of all children at once, causing jank. Additionally, when mapping files to their icons, making synchronous filesystem calls (`existsSync` via `doesFileExist`) for every file within a list build path blocks the main thread completely and results in severe stuttering, especially on Android with slower storage.
+**Action:** Always prefer `ListView.builder` for unbounded or potentially large lists (like file browsers). Crucially, never perform filesystem checks inside `build` or render-path methods; use pre-computed properties or metadata from the directory listing.

--- a/lib/components/split_screen/embedded_file_browser.dart
+++ b/lib/components/split_screen/embedded_file_browser.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:kivixa/data/file_manager/file_manager.dart';
-import 'package:kivixa/pages/editor/editor.dart';
-import 'package:kivixa/pages/textfile/text_file_editor.dart';
 
 /// An embedded file browser for selecting files in split screen view
 class EmbeddedFileBrowser extends StatefulWidget {
@@ -74,17 +72,17 @@ class _EmbeddedFileBrowserState extends State<EmbeddedFileBrowser> {
   }
 
   String _getFileTypeIcon(String filePath) {
-    final fullPath = "${currentPath ?? ''}/$filePath";
-    if (FileManager.doesFileExist('$fullPath${Editor.extension}')) {
-      return 'handwritten';
-    } else if (FileManager.doesFileExist('$fullPath.md')) {
-      return 'markdown';
-    } else if (FileManager.doesFileExist(
-      '$fullPath${TextFileEditor.internalExtension}',
-    )) {
-      return 'text';
+    final fileType = children?.getFileType(filePath);
+    switch (fileType) {
+      case KivixaFileType.handwritten:
+        return 'handwritten';
+      case KivixaFileType.markdown:
+        return 'markdown';
+      case KivixaFileType.text:
+        return 'text';
+      default:
+        return 'unknown';
     }
-    return 'unknown';
   }
 
   IconData _getFileIcon(String fileType) {
@@ -221,33 +219,45 @@ class _EmbeddedFileBrowserState extends State<EmbeddedFileBrowser> {
                       ],
                     ),
                   )
-                : ListView(
+                : ListView.builder(
                     padding: const EdgeInsets.symmetric(vertical: 4),
-                    children: [
-                      // Back button if not at root
-                      if (currentPath != null)
-                        _buildListTile(
-                          icon: Icons.arrow_back,
-                          iconColor: colorScheme.onSurfaceVariant,
-                          title: '..',
-                          subtitle: 'Go back',
-                          onTap: () => _navigateToFolder('..'),
-                          colorScheme: colorScheme,
-                        ),
+                    itemCount: (currentPath != null ? 1 : 0) + children!.directories.length + children!.files.length,
+                    itemBuilder: (context, index) {
+                      int currentIndex = index;
+
+                      // Back button
+                      if (currentPath != null) {
+                        if (currentIndex == 0) {
+                          return _buildListTile(
+                            icon: Icons.arrow_back,
+                            iconColor: colorScheme.onSurfaceVariant,
+                            title: '..',
+                            subtitle: 'Go back',
+                            onTap: () => _navigateToFolder('..'),
+                            colorScheme: colorScheme,
+                          );
+                        }
+                        currentIndex--;
+                      }
+
                       // Folders
-                      for (final folder in children!.directories)
-                        _buildListTile(
+                      if (currentIndex < children!.directories.length) {
+                        final folder = children!.directories[currentIndex];
+                        return _buildListTile(
                           icon: Icons.folder,
                           iconColor: colorScheme.primary,
                           title: folder,
                           subtitle: 'Folder',
                           onTap: () => _navigateToFolder(folder),
                           colorScheme: colorScheme,
-                        ),
+                        );
+                      }
+                      currentIndex -= children!.directories.length;
+
                       // Files
-                      for (final file in children!.files)
-                        _buildFileTile(file, colorScheme),
-                    ],
+                      final file = children!.files[currentIndex];
+                      return _buildFileTile(file, colorScheme);
+                    },
                   ),
           ),
         ],


### PR DESCRIPTION
💡 What: 
1. Changed `ListView` to `ListView.builder` in `EmbeddedFileBrowser` to lazily render list items.
2. Updated `_getFileTypeIcon` to use `children?.getFileType()` for O(1) memory lookup instead of `FileManager.doesFileExist` which performs synchronous disk I/O.
3. Cleaned up unused imports and added a journal entry in `.jules/bolt.md`.

🎯 Why: 
- Synchronous `ListView` instantiates all items at once, which causes jank when opening folders with many files.
- `FileManager.doesFileExist` relies on `existsSync()`. Calling this multiple times per file during the build phase blocks the main UI thread, exacerbating the jank.

📊 Impact: 
- Significantly reduces UI stuttering and jank when navigating to folders with a large number of files.
- Eliminates up to 3 synchronous disk I/O operations per file item rendered.
- Reduces memory footprint by only instantiating visible file list items.

🔬 Measurement: 
Open a split screen embedded file browser in a folder containing hundreds of files. Scrolling and initial load time will be noticeably smoother and faster.

---
*PR created automatically by Jules for task [9913517494262152134](https://jules.google.com/task/9913517494262152134) started by @990aa*