### PR TITLE
Fix bad initial paths for recently imported files

### DIFF
--- a/lib/components/home/new_note_button.dart
+++ b/lib/components/home/new_note_button.dart
@@ -112,13 +112,7 @@ Future<String> importTextLikeNoteAsCopy({
   required String sourcePath,
   required String destinationDir,
 }) async {
-  var safeDestinationDir = destinationDir;
-  if (!safeDestinationDir.startsWith('/')) {
-    safeDestinationDir = '/$safeDestinationDir';
-  }
-  if (!safeDestinationDir.endsWith('/')) {
-    safeDestinationDir = '$safeDestinationDir/';
-  }
+  final safeDestinationDir = FileManager.sanitizeDirectoryPath(destinationDir);
 
   final baseName = importedNoteBaseName(sourcePath);
   final uniqueBasePath = await FileManager.suffixFilePathToMakeItUnique(
@@ -275,7 +269,7 @@ class _NewNoteButtonState extends State<NewNoteButton> {
             if (filePath == null) return;
 
             final importedType = classifyImportedNoteType(filePath);
-            final destinationDir = '${widget.path ?? ''}/';
+            final destinationDir = FileManager.sanitizeDirectoryPath(widget.path);
 
             try {
               switch (importedType) {

--- a/lib/data/file_manager/file_manager.dart
+++ b/lib/data/file_manager/file_manager.dart
@@ -23,6 +23,32 @@ class FileManager {
 
   static final log = Logger('FileManager');
 
+  /// Sanitizes a directory path to ensure it is absolute and properly formatted.
+  ///
+  /// This handles cases where the path might be:
+  /// - `null` or the literal string `"null"` (treated as root `/`)
+  /// - Starting with `"null/"` (strips the prefix)
+  /// - Missing a leading or trailing slash
+  /// - Containing double slashes
+  static String sanitizeDirectoryPath(String? path) {
+    var sanitized = path ?? '/';
+
+    // Handle string "null" or "null/" which can come from the router
+    if (sanitized.startsWith('null/')) {
+      sanitized = sanitized.substring(4);
+    } else if (sanitized == 'null') {
+      sanitized = '/';
+    }
+
+    if (!sanitized.startsWith('/')) sanitized = '/$sanitized';
+    if (!sanitized.endsWith('/')) sanitized = '$sanitized/';
+
+    // Replace multiple slashes with a single one
+    sanitized = sanitized.replaceAll(RegExp(r'/+'), '/');
+
+    return sanitized;
+  }
+
   static const appRootDirectoryPrefix = 'kivixa';
 
   static late String documentsDirectory;
@@ -767,8 +793,10 @@ class FileManager {
     String? extension,
     bool awaitWrite = true,
   }) async {
+    final safeParentDir = sanitizeDirectoryPath(parentDir);
+
     assert(
-      parentDir == null || parentDir.startsWith('/') && parentDir.endsWith('/'),
+      safeParentDir.startsWith('/') && safeParentDir.endsWith('/'),
     );
 
     if (extension == null) {
@@ -801,7 +829,7 @@ class FileManager {
       final mainFileExtension = '.${mainFile.name.split('.').last}'
           .toLowerCase();
       importedPath = await suffixFilePathToMakeItUnique(
-        '${parentDir ?? '/'}$fileName',
+        '$safeParentDir$fileName',
         intendedExtension: mainFileExtension,
       );
       final mainFileContents = () {
@@ -843,7 +871,7 @@ class FileManager {
       final file = File(path);
       final fileContents = await file.readAsBytes();
       importedPath = await suffixFilePathToMakeItUnique(
-        '${parentDir ?? '/'}$fileName',
+        '$safeParentDir$fileName',
         intendedExtension: extension.toLowerCase(),
       );
       writeFutures.add(


### PR DESCRIPTION
This PR fixes a bug where files were sometimes imported with paths starting with `null/` instead of `/`, causing them to be written to incorrect filesystem locations.

I have:
1. Created a shared utility `FileManager.sanitizeDirectoryPath` that robustly handles various malformed path inputs, including literal "null" strings.
2. Refactored the import logic in `NewNoteButton` and `FileManager.importFile` to use this utility.
3. Ensured that all directory paths are properly normalized to be absolute and have correct trailing slashes.

This fix addresses the root cause of the issue mentioned in the codebase's existing mitigation logic.

---
*PR created automatically by Jules for task [12268844434347047676](https://jules.google.com/task/12268844434347047676) started by @990aa*